### PR TITLE
Remove hard json dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,19 @@ PATH
   remote: .
   specs:
     clever-ruby (2.0.1)
-      json (~> 1.8, >= 1.8.3)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ZenTest (4.11.1)
     addressable (2.4.0)
-    autotest (4.4.6)
-      ZenTest (>= 4.4.1)
-    autotest-fsevent (0.2.13)
-      sys-uname
-    autotest-growl (0.2.16)
-    autotest-rails-pure (4.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     hashdiff (0.3.6)
-    json (1.8.6)
     rake (12.0.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -39,9 +30,7 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     safe_yaml (1.0.4)
-    sys-uname (1.0.3)
-      ffi (>= 1.0.0)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
     vcr (3.0.3)
     webmock (1.24.6)
@@ -53,10 +42,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  autotest (~> 4.4, >= 4.4.6)
-  autotest-fsevent (~> 0.2, >= 0.2.12)
-  autotest-growl (~> 0.2, >= 0.2.16)
-  autotest-rails-pure (~> 4.1, >= 4.1.2)
   clever-ruby!
   rake (~> 12.0.0)
   rspec (~> 3.6, >= 3.6.0)
@@ -64,4 +49,4 @@ DEPENDENCIES
   webmock (~> 1.24, >= 1.24.3)
 
 BUNDLED WITH
-   1.15.3
+   1.17.2

--- a/clever-ruby.gemspec
+++ b/clever-ruby.gemspec
@@ -24,20 +24,15 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/swagger-api/swagger-codegen"
   s.summary     = "Clever API Ruby Gem"
   s.description = "The Clever API"
-  # TODO uncommnet and update below with a proper license 
+  # TODO uncommnet and update below with a proper license
   #s.license     = "Apache 2.0"
   s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
   s.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.3'
-  s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
-  s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
-  s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
-  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select{|f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")


### PR DESCRIPTION
This change removes the hard dependency on an older version of the json
gem in favor of whatever version the consumer currently uses. We'll avoid 
an extra C-extension compilation and track with the upstream improvements and security fixes on the `json` bundled with our installed Ruby.

**Also**
Remove older inessential development dependency on autotest that is
incompatible with Ruby 2.6.0.